### PR TITLE
Add jupyter as dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Also, the following packages are required:
 
 __Optional dependencies__ for mapping module and running the Notebooks:
 
+- [`jupyter`](https://jupyter.org/)
 - [`matplotlib`](https://matplotlib.org/)
 - [`pyproj`](https://github.com/jswhit/pyproj)
 - [`cartopy`](https://scitools.org.uk/cartopy/docs/latest/)

--- a/environment.yml
+++ b/environment.yml
@@ -8,6 +8,8 @@ dependencies:
     - numpy
     - scipy
     - cython
+    # Optional dependencies
+    - jupyter
     - matplotlib
     - pyproj
     - cartopy


### PR DESCRIPTION
Part of https://github.com/openjournals/joss-reviews/issues/1544.

Add `jupyter` as dependency in order to be able to run the Notebooks.