### PR TITLE
Add pytest to environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,6 +8,7 @@ dependencies:
     - numpy
     - scipy
     - cython
+    - pytest
     # Optional dependencies
     - jupyter
     - matplotlib


### PR DESCRIPTION
Part of https://github.com/openjournals/joss-reviews/issues/1544.

Add pytest to conda environment file because it's needed for running the tests.