### PR TITLE
Fix Tanaka to fit the amplitude spectrum

### DIFF
--- a/Examples/Notebooks/Tanaka/Ex1-Plot-amplitude-spectrum.ipynb
+++ b/Examples/Notebooks/Tanaka/Ex1-Plot-amplitude-spectrum.ipynb
@@ -4,16 +4,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Example 1 - Plot power spectra\n",
+    "# Example 1 - Plot amplitude spectra\n",
     "\n",
-    "`PyCurious` offers convenience functions to extract the radial power spectrum. This has been covered in the Bouligand folder of jupyter notebooks and is largely duplicated here.\n",
+    "`PyCurious` offers convenience functions to extract the radial amplitude spectrum. This has been covered in the Bouligand folder of jupyter notebooks and is largely duplicated here.\n",
     "\n",
-    "In this notebook we plot the radial power spectrum using the analytical expression, and the spectrum computed from a synthetic magnetic anomaly. (This can be generated from `Bouligand_forward.py` in the `tests` directory.)\n",
+    "In this notebook we plot the amplitude power spectrum using the analytical expression, and the spectrum computed from a synthetic magnetic anomaly. (This can be generated from `Bouligand_forward.py` in the `tests` directory.)\n",
     "\n",
     "### Contents\n",
     "\n",
-    "- [Radial power spectrum](#Power-spectrum-from-FFT)\n",
-    "- [Azimuthal power spectrum](#Azimuthal-power-spectrum)"
+    "- [Radial amplitude spectrum](#Power-spectrum-from-FFT)"
    ]
   },
   {
@@ -33,17 +32,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Radial power spectrum\n",
+    "## Radial amplitude spectrum\n",
     "\n",
-    "The radial power spectrum is computed from a square window of the magnetic anomaly. Methods to select window sizes and compute the Fast Fourier Transform (FFT) belong to the `CurieGrid` object.\n",
+    "The radial amplitude spectrum is computed from a square window of the magnetic anomaly. Methods to select window sizes and compute the Fast Fourier Transform (FFT) belong to the `CurieGrid` object.\n",
     "\n",
     "`CurieGrid` achieves the following purposes:\n",
     "\n",
     "- Upward continuation\n",
     "- Reduction to the pole\n",
-    "- Compute the radial power spectrum using FFT\n",
+    "- Compute the radial amplitude spectrum using FFT\n",
     "\n",
-    "The shape of the radial power spectrum is heavily dependent on window size. Resolution of long wavelength features require large windows.\n",
+    "The shape of the radial amplitude spectrum is heavily dependent on window size. Resolution of long wavelength features require large windows.\n",
     "\n",
     "> Suggestion: use a window size **> 4 times** the maximum Curie depth.\n"
    ]
@@ -105,11 +104,11 @@
    "outputs": [],
    "source": [
     "# compute radial power spectrum\n",
-    "k, Phi, sigma_Phi = grid.radial_spectrum(subgrid, taper=None, power=0.5)\n",
+    "k, Phi, sigma_Phi = grid.radial_spectrum(subgrid, taper=None, power=1)\n",
     "\n",
     "# plot radial power spectrum\n",
     "fig = plt.figure()\n",
-    "ax1 = fig.add_subplot(111, xlabel=\"wavenumber (rad/km)\", ylabel=\"radial power spectrum\")\n",
+    "ax1 = fig.add_subplot(111, xlabel=\"wavenumber (rad/km)\", ylabel=\"radial amplitude spectrum\")\n",
     "ax1.plot(k, Phi, '-o')\n",
     "plt.show()"
    ]
@@ -120,7 +119,7 @@
    "source": [
     "**Choice of taper**\n",
     "\n",
-    "The default taper is the hanning filter (see [`numpy.hanning`](#hanning) for more details), but other functions can be passed to taper, or simply set it to `None`. There is a significant offset in the power spectrum with tapering functions, however, it is the *slope* of the spectrum with wavenumber that is most important when it comes to determining Curie depth."
+    "The default taper is the hanning filter (see [`numpy.hanning`](#hanning) for more details), but other functions can be passed to taper, or simply set it to `None`. There is a significant offset in the amplitude spectrum with tapering functions, however, it is the *slope* of the spectrum with wavenumber that is most important when it comes to determining Curie depth."
    ]
   },
   {
@@ -130,13 +129,13 @@
    "outputs": [],
    "source": [
     "\n",
-    "k1, Phi1, sigma_Phi1 = grid.radial_spectrum(subgrid, taper=None, power=0.5)\n",
-    "k2, Phi2, sigma_Phi2 = grid.radial_spectrum(subgrid, taper=np.hanning, power=0.5)\n",
-    "k3, Phi3, sigma_Phi2 = grid.radial_spectrum(subgrid, taper=np.hamming, power=0.5)\n",
+    "k1, Phi1, sigma_Phi1 = grid.radial_spectrum(subgrid, taper=None, power=1)\n",
+    "k2, Phi2, sigma_Phi2 = grid.radial_spectrum(subgrid, taper=np.hanning, power=1)\n",
+    "k3, Phi3, sigma_Phi2 = grid.radial_spectrum(subgrid, taper=np.hamming, power=1)\n",
     "\n",
     "\n",
     "fig = plt.figure()\n",
-    "ax1 = fig.add_subplot(111, xlabel=\"wavenumber (rad/km)\", ylabel=\"radial power spectrum\")\n",
+    "ax1 = fig.add_subplot(111, xlabel=\"wavenumber (rad/km)\", ylabel=\"radial amplitude spectrum\")\n",
     "ax1.plot(k1, Phi1, '-o', label='none')\n",
     "ax1.plot(k2, Phi2, '-o', label='hanning')\n",
     "ax1.plot(k3, Phi3, '-o', label='hamming')\n",
@@ -167,8 +166,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.9.10"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/Examples/Notebooks/Tanaka/Ex2-Compute-Curie-depth.ipynb
+++ b/Examples/Notebooks/Tanaka/Ex2-Compute-Curie-depth.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "# Example 2 - Compute Curie depth\n",
-    "Tanaka *et al.* (1999) based their method upon an expression for the radial power spectrum that assumes random magnetisation of the crust, and a radially averaged power spectra $\\Phi_{\\Delta T}(|k|)$:\n",
+    "Tanaka *et al.* (1999) based their method upon an expression for the radial amplitude spectrum that assumes random magnetisation of the crust, and a radially averaged power spectra $\\Phi_{\\Delta T}(|k|)$:\n",
     "\n",
     "$$(1) \\Phi_{\\Delta T}(|k|)=Ae^{-2|k|Z_t}(1-e^{-|k|(Z_b-Z_t)})^2$$\n",
     "\n",
@@ -75,8 +75,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Plot radial power spectrum\n",
-    "The radial power spectrum is computed from a square window of the magnetic anomaly. Methods to select window sizes and compute the Fast Fourier Transform (FFT) belong to the `CurieGrid` object. We apply the default `np.hanning` taper to the power spectrum as in [Ex1-Plot-power-spectrum](#./Ex1-Plot-power-spectrum.ipynb).\n",
+    "## Plot radial amplitude spectrum\n",
+    "The radial amplitude spectrum is computed from a square window of the magnetic anomaly. Methods to select window sizes and compute the Fast Fourier Transform (FFT) belong to the `CurieGrid` object. We apply the default `np.hanning` taper to the amplitude spectrum as in [Ex1-Plot-power-spectrum](#./Ex1-Plot-power-spectrum.ipynb).\n",
     "\n",
     "By default the FFT of the magnetic anomaly is raised to the power 2:\n",
     "\n",
@@ -84,7 +84,7 @@
     "grid.radial_spectrum(subgrid, taper=None, power=2.0, **kwargs)\n",
     "```\n",
     "\n",
-    "which is compatible with Bouligand _et al._ (2009) computation of Curie depth. For Tanaka *et al.* (1999), however, we need to take the square root which is set with `power=0.5`."
+    "which is compatible with Bouligand _et al._ (2009) computation of Curie depth. For Tanaka *et al.* (1999), however, we need to use the amplitude spectrum directly, which is set with `power=1`."
    ]
   },
   {
@@ -111,11 +111,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "k, Phi, sigma_Phi = grid.radial_spectrum(subgrid, taper=None, power=0.5)\n",
+    "k, Phi, sigma_Phi = grid.radial_spectrum(subgrid, taper=None, power=1)\n",
     "\n",
-    "# Plot of power spectrum, as function of spatial frequency\n",
+    "# Plot of amplitude spectrum, as function of spatial frequency\n",
     "plt.plot(k/(2*np.pi), Phi/(2*np.pi), '-o')\n",
-    "plt.title('Power Spectrum')\n",
+    "plt.title('Amplitude Spectrum')\n",
     "plt.xlabel(r'$|k|/(2\\pi)$ [km$^{-1}$]')\n",
     "plt.ylabel(r'$\\ln(\\Phi_{\\Delta T}(|k|)^{1/2})/(2\\pi)$')\n",
     "plt.show()"
@@ -130,7 +130,7 @@
     "Phi_n = np.log(np.exp(Phi)/k)\n",
     "\n",
     "plt.plot(k/(2*np.pi), Phi_n/(2*np.pi), '-o')\n",
-    "plt.title('Power Spectrum, weighted by k')\n",
+    "plt.title('Amplitude Spectrum, weighted by k')\n",
     "plt.xlabel(r'$|k|/(2\\pi)$ [km$^{-1}$]')\n",
     "plt.ylabel(r'$\\ln(\\Phi_{\\Delta T}(|k|)^{1/2}/|k|)/(2\\pi)$')\n",
     "plt.show()"
@@ -150,9 +150,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "z0_min, z0_max = 0.0, 0.1\n",
@@ -178,7 +176,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Plot of power spectrum, as function of spatial frequency\n",
+    "# Plot of amplitude spectrum, as function of spatial frequency\n",
     "\n",
     "def linear_func(x, a, b):\n",
     "    return x*a + b\n",
@@ -188,7 +186,7 @@
     "Phi_scaled = Phi/(2*np.pi)\n",
     "Phi_n_scaled = Phi_n/(2*np.pi)\n",
     "\n",
-    "# mask ranges of power spectrum\n",
+    "# mask ranges of amplitude spectrum\n",
     "mask_zt = np.logical_and(k_scaled >= zt_min, k_scaled <= zt_max)\n",
     "mask_z0 = np.logical_and(k_scaled >= z0_min, k_scaled <= z0_max)\n",
     "\n",
@@ -198,14 +196,14 @@
     "\n",
     "fig, (ax1, ax2) = plt.subplots(1,2, figsize=(15,6),)\n",
     "\n",
-    "ax1.plot(k_scaled, Phi_scaled, '-o', label='Power spectrum')\n",
+    "ax1.plot(k_scaled, Phi_scaled, '-o', label='Amplitude spectrum')\n",
     "ax1.plot(k_scaled[mask_zt], linear_func(k_scaled[mask_zt], zt, zt_int), 'r-', linewidth=3, label='Line of fit')\n",
     "ax1.legend()\n",
     "ax1.set_xlabel(r'$|k|/(2\\pi)$ [km$^{-1}$]')\n",
     "ax1.set_ylabel(r'$\\ln(\\Phi_{\\Delta T}(|k|)^{1/2})/(2\\pi)$')\n",
     "\n",
     "\n",
-    "ax2.plot(k_scaled, Phi_n_scaled, '-o', label='Power spectrum')\n",
+    "ax2.plot(k_scaled, Phi_n_scaled, '-o', label='Amplitude spectrum')\n",
     "ax2.plot(k_scaled[mask_z0], linear_func(k_scaled[mask_z0], z0, z0_int), 'r-', linewidth=3, label='Line of fit')\n",
     "ax2.legend()\n",
     "ax2.set_xlabel(r'$|k|/(2\\pi)$ [km$^{-1}$]')\n",
@@ -236,8 +234,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.9.10"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/pycurious/optimise_tanaka.py
+++ b/pycurious/optimise_tanaka.py
@@ -41,7 +41,7 @@ class CurieOptimiseTanaka(CurieGrid):
         subgrid = process_subgrid(subgrid)
 
         # calcualte spectra
-        k, Phi, sigma_Phi = self.radial_spectrum(subgrid, taper=taper, power=0.5)
+        k, Phi, sigma_Phi = self.radial_spectrum(subgrid, taper=taper, power=1)
         Phi_n = np.log(np.exp(Phi)/k)
         sigma_Phi_n = np.log(np.exp(sigma_Phi)/k)
 


### PR DESCRIPTION
Tanaka et al (1999) use the square root of the power spectrum (i.e., the amplitude spectrum). CurieGrid.radial_spectrum() returns the amplitude spectrum, so it should be raised only to the power=1, rather than power=0.5.